### PR TITLE
Update haproxy.cfg

### DIFF
--- a/2.2/haproxy.cfg
+++ b/2.2/haproxy.cfg
@@ -67,7 +67,7 @@ defaults
 #     user admin insecure-password mypassword
 #
 # program api
-#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist hapee-dataplaneapi
+#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /usr/local/etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist hapee-dataplaneapi
 #    no option start-on-reload
 
 #---------------------------------------------------------------------


### PR DESCRIPTION
If the example block of the dataplane api is used will appear the error when the container starts:
```
<container-name>_1  | time="2021-02-24T17:27:16Z" level=fatal msg="The configuration file is not declared in the HAPROXY_CFGFILES environment variable, cannot start."
```

This PR fixes the example to avoid this situation.