### PR TITLE
Remove external libslz as it is now included in haproxy

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -17,19 +17,12 @@ ENV DATAPLANE_MINOR 2.2.1
 ENV DATAPLANE_SHA256 0017cd9ce316ea4b4a27cbd87f6edb842cfd55144fd6f159cebdb2d4f501a72f
 ENV DATAPLANE_URL https://github.com/haproxytech/dataplaneapi/releases/download
 
-ENV LIBSLZ_VERSION 1.2.0
-
 ENV HAPROXY_UID haproxy
 ENV HAPROXY_GID haproxy
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends procps libssl1.1 zlib1g "libpcre2-*" liblua5.3-0 tar curl socat ca-certificates && \
     apt-get install -y --no-install-recommends gcc make libc6-dev libssl-dev libpcre2-dev zlib1g-dev liblua5.3-dev && \
-    curl -sfSL "http://git.1wt.eu/web?p=libslz.git;a=snapshot;h=v${LIBSLZ_VERSION};sf=tgz" -o libslz.tar.gz && \
-    mkdir -p /tmp/libslz && \
-    tar -xzf libslz.tar.gz -C /tmp/libslz --strip-components=1 && \
-    make -C /tmp/libslz static && \
-    rm -f libslz.tar.gz && \
     curl -sfSL "${HAPROXY_SRC_URL}/${HAPROXY_BRANCH}/src/devel/haproxy-${HAPROXY_MINOR}.tar.gz" -o haproxy.tar.gz && \
     echo "$HAPROXY_SHA256 *haproxy.tar.gz" | sha256sum -c - && \
     groupadd "$HAPROXY_GID" && \
@@ -39,7 +32,7 @@ RUN apt-get update && \
     rm -f haproxy.tar.gz && \
     make -C /tmp/haproxy -j"$(nproc)" TARGET=linux-glibc CPU=generic USE_PCRE2=1 USE_PCRE2_JIT=1 USE_REGPARM=1 USE_OPENSSL=1 \
                             USE_TFO=1 USE_LINUX_TPROXY=1 USE_LUA=1 USE_GETADDRINFO=1 \
-                            USE_PROMEX=1 USE_SLZ=1 SLZ_INC=/tmp/libslz/src SLZ_LIB=/tmp/libslz \
+                            USE_PROMEX=1 USE_SLZ=1 \
                             all && \
     make -C /tmp/haproxy TARGET=linux-glibc install-bin install-man && \
     ln -s /usr/local/sbin/haproxy /usr/sbin/haproxy && \
@@ -48,7 +41,6 @@ RUN apt-get update && \
     mkdir -p /usr/local/etc/haproxy && \
     ln -s /usr/local/etc/haproxy /etc/haproxy && \
     cp -R /tmp/haproxy/examples/errorfiles /usr/local/etc/haproxy/errors && \
-    rm -rf /tmp/libslz && \
     rm -rf /tmp/haproxy && \
     apt-get purge -y --auto-remove gcc make libc6-dev libssl-dev libpcre2-dev zlib1g-dev liblua5.3-dev && \
     apt-get clean && \


### PR DESCRIPTION
haproxy 2.4-dev17 includes libslz in the tarball. ~It is activated by USE_SLZ=1 alone.~ It is enabled by default, or explicitly with USE_SLZ=1. The SLZ_LIB and SLZ_INC variables are removed.

I can, or you all can, copy this same PR to the other haproxytech/haproxy-docker-<foo> repositories. Thanks!