### PR TITLE
Fixes dataplane api example on 2.2

### DIFF
--- a/2.2/haproxy.cfg
+++ b/2.2/haproxy.cfg
@@ -67,7 +67,7 @@ defaults
 #     user admin insecure-password mypassword
 #
 # program api
-#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd="kill -SIGUSR2 1" --reload-delay 5 --userlist hapee-dataplaneapi
+#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist hapee-dataplaneapi
 #    no option start-on-reload
 
 #---------------------------------------------------------------------

--- a/2.2/haproxy.cfg
+++ b/2.2/haproxy.cfg
@@ -67,7 +67,7 @@ defaults
 #     user admin insecure-password mypassword
 #
 # program api
-#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist hapee-dataplaneapi
+#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd="kill -SIGUSR2 1" --reload-delay 5 --userlist hapee-dataplaneapi
 #    no option start-on-reload
 
 #---------------------------------------------------------------------


### PR DESCRIPTION
Fix documentation to avoid container to exit when regular restarts happens.

Without the `--restart-cmd="kill -SIGUSR2 1"` the container exits with something like:

```
haproxy_1  | time="2021-06-09T18:42:01Z" level=info msg="Reloaded Data Plane API"
haproxy_1  | time="2021-06-09T18:42:02Z" level=info msg="HAProxy Data Plane API v2.3.1 488df37"
haproxy_1  | time="2021-06-09T18:42:02Z" level=info msg="Build from: git@github.com:haproxytech/dataplaneapi.git"
haproxy_1  | time="2021-06-09T18:42:02Z" level=info msg="Build date: 2021-05-20T12:55:00Z"
haproxy_1  | time="2021-06-09T18:42:02Z" level=fatal msg="listen tcp 0.0.0.0:5555: bind: address already in use"
haproxy_1  | [NOTICE] 159/184202 (1) : haproxy version is 2.2.14-a07ac36
haproxy_1  | [NOTICE] 159/184202 (1) : path to executable is /usr/local/sbin/haproxy
haproxy_1  | [ALERT] 159/184202 (1) : Current program 'api' (25) exited with code 1 (Exit)
haproxy_1  | [ALERT] 159/184202 (1) : exit-on-failure: killing every processes with SIGTERM
haproxy_1  | time="2021-06-09T18:42:02Z" level=info msg="Shutting down... "
haproxy_1  | [ALERT] 159/184202 (1) : Current worker #1 (26) exited with code 143 (Terminated)
haproxy_1  | time="2021-06-09T18:42:02Z" level=info msg="Stopped serving data plane at http://[::]:5555"
haproxy_1  | time="2021-06-09T18:42:02Z" level=info msg=terminated
haproxy_1  | time="2021-06-09T18:42:02Z" level=info msg="HAProxy Data Plane API shutting down"
haproxy_1  | [WARNING] 159/184202 (1) : Former program 'api' (8) exited with code 0 (Exit)
haproxy_1  | [WARNING] 159/184202 (1) : All workers exited. Exiting... (1)
```

There is more information at the issue https://github.com/haproxytech/dataplaneapi/issues/75.

This PR only changes 2.2 version which is were I've tested it, probably it also should be fixed on the example of the other versions.