### PR TITLE
fix: incorrect dataplane userlist arg value

### DIFF
--- a/2.0/haproxy.cfg
+++ b/2.0/haproxy.cfg
@@ -67,7 +67,7 @@ defaults
 #     user admin insecure-password mypassword
 #
 # program api
-#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist hapee-dataplaneapi
+#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
 #    no option start-on-reload
 
 #---------------------------------------------------------------------

--- a/2.2/haproxy.cfg
+++ b/2.2/haproxy.cfg
@@ -67,7 +67,7 @@ defaults
 #     user admin insecure-password mypassword
 #
 # program api
-#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist hapee-dataplaneapi
+#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
 #    no option start-on-reload
 
 #---------------------------------------------------------------------

--- a/2.4/haproxy.cfg
+++ b/2.4/haproxy.cfg
@@ -67,7 +67,7 @@ defaults
 #     user admin insecure-password mypassword
 #
 # program api
-#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist hapee-dataplaneapi
+#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
 #    no option start-on-reload
 
 #---------------------------------------------------------------------

--- a/2.6/haproxy.cfg
+++ b/2.6/haproxy.cfg
@@ -67,7 +67,7 @@ defaults
 #     user admin insecure-password mypassword
 #
 # program api
-#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist hapee-dataplaneapi
+#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
 #    no option start-on-reload
 
 #---------------------------------------------------------------------

--- a/2.7/haproxy.cfg
+++ b/2.7/haproxy.cfg
@@ -67,7 +67,7 @@ defaults
 #     user admin insecure-password mypassword
 #
 # program api
-#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist hapee-dataplaneapi
+#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
 #    no option start-on-reload
 
 #---------------------------------------------------------------------

--- a/2.8/haproxy.cfg
+++ b/2.8/haproxy.cfg
@@ -67,7 +67,7 @@ defaults
 #     user admin insecure-password mypassword
 #
 # program api
-#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist hapee-dataplaneapi
+#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
 #    no option start-on-reload
 
 #---------------------------------------------------------------------

--- a/2.9/haproxy.cfg
+++ b/2.9/haproxy.cfg
@@ -67,7 +67,7 @@ defaults
 #     user admin insecure-password mypassword
 #
 # program api
-#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist hapee-dataplaneapi
+#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
 #    no option start-on-reload
 
 #---------------------------------------------------------------------

--- a/3.0/haproxy.cfg
+++ b/3.0/haproxy.cfg
@@ -67,7 +67,7 @@ defaults
 #     user admin insecure-password mypassword
 #
 # program api
-#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist hapee-dataplaneapi
+#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
 #    no option start-on-reload
 
 #---------------------------------------------------------------------


### PR DESCRIPTION
The example value provided for the --userlist argument to the dataplaneapi is incorrect in every configuration file.