### PR TITLE
fix: incorrect dataplane config path

### DIFF
--- a/2.0/haproxy.cfg
+++ b/2.0/haproxy.cfg
@@ -67,7 +67,7 @@ defaults
 #     user admin insecure-password mypassword
 #
 # program api
-#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
+#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /usr/local/etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
 #    no option start-on-reload
 
 #---------------------------------------------------------------------

--- a/2.2/haproxy.cfg
+++ b/2.2/haproxy.cfg
@@ -67,7 +67,7 @@ defaults
 #     user admin insecure-password mypassword
 #
 # program api
-#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
+#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /usr/local/etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
 #    no option start-on-reload
 
 #---------------------------------------------------------------------

--- a/2.4/haproxy.cfg
+++ b/2.4/haproxy.cfg
@@ -67,7 +67,7 @@ defaults
 #     user admin insecure-password mypassword
 #
 # program api
-#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
+#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /usr/local/etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
 #    no option start-on-reload
 
 #---------------------------------------------------------------------

--- a/2.6/haproxy.cfg
+++ b/2.6/haproxy.cfg
@@ -67,7 +67,7 @@ defaults
 #     user admin insecure-password mypassword
 #
 # program api
-#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
+#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /usr/local/etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
 #    no option start-on-reload
 
 #---------------------------------------------------------------------

--- a/2.7/haproxy.cfg
+++ b/2.7/haproxy.cfg
@@ -67,7 +67,7 @@ defaults
 #     user admin insecure-password mypassword
 #
 # program api
-#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
+#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /usr/local/etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
 #    no option start-on-reload
 
 #---------------------------------------------------------------------

--- a/2.8/haproxy.cfg
+++ b/2.8/haproxy.cfg
@@ -67,7 +67,7 @@ defaults
 #     user admin insecure-password mypassword
 #
 # program api
-#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
+#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /usr/local/etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
 #    no option start-on-reload
 
 #---------------------------------------------------------------------

--- a/2.9/haproxy.cfg
+++ b/2.9/haproxy.cfg
@@ -67,7 +67,7 @@ defaults
 #     user admin insecure-password mypassword
 #
 # program api
-#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
+#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /usr/local/etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
 #    no option start-on-reload
 
 #---------------------------------------------------------------------

--- a/3.0/haproxy.cfg
+++ b/3.0/haproxy.cfg
@@ -67,7 +67,7 @@ defaults
 #     user admin insecure-password mypassword
 #
 # program api
-#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
+#    command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /usr/local/etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --restart-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
 #    no option start-on-reload
 
 #---------------------------------------------------------------------


### PR DESCRIPTION
I forgot to include this in the last PR (Oops)...
Using the example path (/etc/haproxy/haproxy.cfg) results in the following error:

> The configuration file is not declared in the HAPROXY_CFGFILES environment variable, cannot start.

The correct path can be seen in the Readme docker mounting example:
`$ docker run -d --name my-running-haproxy -v /path/to/etc/haproxy:/usr/local/etc/haproxy:ro haproxytech/haproxy-debian:2.7`